### PR TITLE
Now builds OpenDJ.jar rather than OpenDJ-CE.jar

### DIFF
--- a/PRODUCT
+++ b/PRODUCT
@@ -2,7 +2,7 @@
 PRODUCT_NAME=OpenDJ Community Edition
 
 # The short name that should be used if the full name is not appropriate.
-SHORT_NAME=OpenDJ-CE
+SHORT_NAME=OpenDJ
 
 # The short name that should be used in packages.
 PKG_NAME=opendj


### PR DESCRIPTION
Which is essential for creating OpenAM Community Edition's
embedded OpenDJ.